### PR TITLE
Add `GH_SCM_TOKEN` in workflows

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -10,8 +10,6 @@ on:
 
 env:
   DEST_BRANCH: 'pages'
-  SCM_USER: ${{ secrets.SCM_USER }}
-  SCM_EMAIL: ${{ secrets.SCM_EMAIL }}
 
 jobs:
   deploy:
@@ -23,13 +21,16 @@ jobs:
           fetch-depth: 0
 
       - name: Config git
+        env:
+          SCM_USER: ${{ secrets.SCM_USER }}
+          SCM_EMAIL: ${{ secrets.SCM_EMAIL }}
         run: |
           git config --local user.name "${SCM_USER}"
           git config --local user.email "${SCM_EMAIL}"
 
       - name: Check if pages branch exist and create
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_SCM_TOKEN }}
         run: |
           # Check if ${DEST_BRANCH} branch exist
           if [[ -z $(git ls-remote --heads origin "${DEST_BRANCH}") ]]; then

--- a/.github/workflows/pack-add-image.yml
+++ b/.github/workflows/pack-add-image.yml
@@ -94,6 +94,8 @@ jobs:
           git config --local user.email "${SCM_EMAIL}"
 
       - name: Commit changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_SCM_TOKEN }}
         run: |
           git add .
           git commit -m "feat: Add image ${{ inputs.image-name }} to pack ${{ inputs.pack-id }}"

--- a/.github/workflows/pack-add-imported.yml
+++ b/.github/workflows/pack-add-imported.yml
@@ -48,6 +48,8 @@ jobs:
           git config --local user.email "${SCM_EMAIL}"
 
       - name: Commit changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_SCM_TOKEN }}
         run: |
           git add .
           git commit -m "feat: Add imported packs ${{ inputs.pack-ids }}"

--- a/.github/workflows/pack-create.yml
+++ b/.github/workflows/pack-create.yml
@@ -65,6 +65,8 @@ jobs:
           git config --local user.email "${SCM_EMAIL}"
 
       - name: Commit changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_SCM_TOKEN }}
         run: |
           git add .
           git commit -m "Create new pack ${{ inputs.pack-name }}"

--- a/.github/workflows/user-add-packs.yml
+++ b/.github/workflows/user-add-packs.yml
@@ -1,5 +1,5 @@
 ---
-name: user-add-pack
+name: user-add-packs
 
 run-name: Add packs ${{ inputs.packs }} to ${{ inputs.username }}...
 
@@ -57,6 +57,8 @@ jobs:
           git config --local user.email "${SCM_EMAIL}"
 
       - name: Commit changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_SCM_TOKEN }}
         run: |
           git add .
           git commit -m "Add new packs to ${{ inputs.username }}"

--- a/.github/workflows/user-del-packs.yml
+++ b/.github/workflows/user-del-packs.yml
@@ -57,6 +57,8 @@ jobs:
           git config --local user.email "${SCM_EMAIL}"
 
       - name: Commit changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_SCM_TOKEN }}
         run: |
           git add .
           git commit -m "Add new packs to ${{ inputs.username }}"

--- a/.github/workflows/user-install.yml
+++ b/.github/workflows/user-install.yml
@@ -102,6 +102,8 @@ jobs:
 
       - name: Commit changes
         if: ${{ env.CHANGED == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_SCM_TOKEN }}
         run: |
           git add .
           git commit -m "feat: Add new sticker selection to ${{ inputs.username }}"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ To use this utility you need to have installed
 Define as secrets in the repository:
 - `SCM_USER`: GitHub user name.
 - `SCM_EMAIL`: GitHub user email.
+- `GH_SCM_TOKEN`: GitHub user token with repo permissions.
 
 These are used in GitHub workflows.
 
@@ -171,7 +172,7 @@ Arguments:
 Options:
 * `--username`: User name without `@` and `:domain` (required)
 
-You can also run this [workflow](https://github.com/mariocarpente/stickerpicker/actions/workflows/user-add-pack.yml)
+You can also run this [workflow](https://github.com/mariocarpente/stickerpicker/actions/workflows/user-add-packs.yml)
 
 ### **Delete pack a user**
 Execute the following command:


### PR DESCRIPTION
If you change the default `GITHUB_TOKEN`, the push to branches may trigger other workflows.